### PR TITLE
fix: implement title smartly

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,7 +6,7 @@ export default {
    ** Headers of the page
    */
   head: {
-    titleTemplate: '%s - ' + 'Heyho',
+    titleTemplate: '%s - Heyho',
     title: process.env.npm_package_name || '',
     meta: [
       { charset: 'utf-8' },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,6 +5,7 @@ export default {
   /*
    ** Headers of the page
    */
+
   head: {
     titleTemplate: '%s - Heyho',
     title: process.env.npm_package_name || '',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,15 +6,14 @@ export default {
    ** Headers of the page
    */
   head: {
-    titleTemplate: '%s - ' + process.env.npm_package_name,
+    titleTemplate: '%s - ' + 'Heyho',
     title: process.env.npm_package_name || '',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         hid: 'description',
-        name: 'description',
-        content: process.env.npm_package_description || ''
+        name: 'description'
       }
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
   }),
   head() {
     return {
-      title: 'HeyHo - About Us',
+      title: 'About Us',
       meta: [
         {
           hid: 'About page',

--- a/pages/box-shadow-generator.vue
+++ b/pages/box-shadow-generator.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
   },
   head() {
     return {
-      title: 'HeyHo - Box Shadow Generator',
+      title: 'Box Shadow Generator',
       meta: [
         {
           hid: 'box shadow generator',

--- a/pages/color-picker.vue
+++ b/pages/color-picker.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   },
   head() {
     return {
-      title: 'HeyHo - Color Picker and Theme Viewer',
+      title: 'Color Picker and Theme Viewer',
       meta: [
         {
           hid: 'color picker and theme viewer',

--- a/pages/credit-card-generator.vue
+++ b/pages/credit-card-generator.vue
@@ -70,6 +70,19 @@ export default Vue.extend({
       navigator.clipboard.writeText(this.card)
       this.snackbar = true
     }
+  },
+  head() {
+    return {
+      title: 'Credit Card Generator',
+      meta: [
+        {
+          hid: 'credit card generator',
+          name: 'Credit Card Generator',
+          content:
+            'A credit card generator to get an ready-to-use credit-card valid number'
+        }
+      ]
+    }
   }
 })
 </script>

--- a/pages/css-filters.vue
+++ b/pages/css-filters.vue
@@ -117,7 +117,7 @@ export default Vue.extend({
   },
   head() {
     return {
-      title: 'HeyHo - CSS Filters',
+      title: 'CSS Filters',
       meta: [
         {
           hid: 'css filters',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,7 +25,7 @@ export default {
   }),
   head() {
     return {
-      title: 'HeyHo - Ready to Use Development Tools',
+      title: 'Ready to Use Development Tools',
       meta: [
         {
           hid: 'ready to use development tools',

--- a/pages/regex-replace-viewer.vue
+++ b/pages/regex-replace-viewer.vue
@@ -34,7 +34,7 @@ export default Vue.extend({
   },
   head() {
     return {
-      title: 'HeyHo - Regex Replace Viewer',
+      title: 'Regex Replace Viewer',
       meta: [
         {
           hid: 'regex replace viewer',


### PR DESCRIPTION
## Related issues

Closes #11 

## Proposed changes

Nuxt has a default `head` object that controls how the title should be shown in case the developer doesn't provide a name for it. Though, in production, the project name was `undefined`. I added a hardcoded `Heyho` string to `nuxt.config` so this problem will occur no more.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
